### PR TITLE
Fix reference to the GitHub reusable workflow for Terraform

### DIFF
--- a/.github/workflows/terraform-integrations.yaml
+++ b/.github/workflows/terraform-integrations.yaml
@@ -2,9 +2,11 @@
 name: Terraform Integrations
 
 on:
+  # Configure this integration workflow up to be called by other workflows only
+  # (i.e. the terraform-trigger-label and terraform-trigger-pr workflows in this
+  # repository). No inputs are required, as all information about the event will
+  # be pulled in from the context of the event itself
   workflow_call:
-    # No inputs are required, as all information about the event will be pulled
-    # in from the context of the event itself
 
 permissions:
   id-token: write
@@ -16,7 +18,7 @@ permissions:
 jobs:
   configuration:
     name: Configuration
-    uses: n3tuk/workflow-reusable-terraform/.github/workflows/terraform-checks.yaml@v1.1.0
+    uses: n3tuk/workflows-reusable-terraform/.github/workflows/terraform-checks.yaml@v1.1
     secrets: inherit
     with:
       working-directory: terraform


### PR DESCRIPTION
Fix the reference to the GitHub reusable workflow for Terraform in this repository to ensure that the Terraform workflows can be run and the pull requests checked.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
