### PR TITLE
Add `node-01` and `node-02` IPv6 addresses for production

### DIFF
--- a/terraform/kub3-node.tf
+++ b/terraform/kub3-node.tf
@@ -4,11 +4,13 @@ locals {
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.2"
+      ipv6        = "2a00:8010:8006:3a32:4a21:bff:fe55:f359"
     },
     { name        = "node-02"
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.3"
+      ipv6        = "2a00:8010:8006:3a32:4a21:bff:fe55:450"
     },
     { name        = "node-03"
       environment = "production"


### PR DESCRIPTION
Add the IPv6 addresses for `node-01` and `node-02` in `production` to test the initial setting of IPv6 addresses.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
