### PR TITLE
Add remaining IPv6 addresses for kub3 notes

### DIFF
--- a/terraform/kub3-node.tf
+++ b/terraform/kub3-node.tf
@@ -4,43 +4,49 @@ locals {
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.2"
-      ipv6        = "2a00:8010:8006:3a32:4a21:bff:fe55:f359"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:f359"
     },
     { name        = "node-02"
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.3"
-      ipv6        = "2a00:8010:8006:3a32:4a21:bff:fe55:450"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:450"
     },
     { name        = "node-03"
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.4"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:f375"
     },
     { name        = "node-04"
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.5"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:f32f"
     },
     { name        = "node-05"
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.6"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:f336"
     },
     { name        = "node-06"
       environment = "production"
       region      = "cym-south-1"
       ipv4        = "172.23.32.7"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:f393"
     },
     { name        = "node-01"
       environment = "development"
       region      = "cym-south-1"
       ipv4        = "172.23.32.8"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe55:ed14"
     },
     { name        = "node-02"
       environment = "development"
       region      = "cym-south-1"
       ipv4        = "172.23.32.9"
+      ipv6        = "2a02:8010:8006:3a32:4a21:bff:fe56:446"
     },
   ]
 }


### PR DESCRIPTION
Add the remaining IPv6 addresses for the kub3 nodes, and fix the two addresses for `node-01` and `node-02` as these were incorrect.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
