### PR TITLE
Move `minikube-01` to `testing-01` for new clusters

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,13 +16,13 @@ the high-level records and resources for the management of the DNS for the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5.0 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 4.20.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 4.24.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.20.0 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.24.0 |
 
 ## Modules
 

--- a/terraform/kub3-testing.tf
+++ b/terraform/kub3-testing.tf
@@ -1,6 +1,6 @@
 locals {
   kub3_minikube = [
-    { name        = "minikube-01"
+    { name        = "testing-01"
       environment = "testing"
       region      = "cym-south-1"
       ipv4        = "172.23.39.2"


### PR DESCRIPTION
Move the `minikube-01` host to `testing-01` for the new cluster as it is now k3s-based rather than minikube-based.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
