### PR TITLE
Correct the IPv6 address for `testing-01`

### DIFF
--- a/terraform/kub3-testing.tf
+++ b/terraform/kub3-testing.tf
@@ -4,7 +4,7 @@ locals {
       environment = "testing"
       region      = "cym-south-1"
       ipv4        = "172.23.39.2"
-      ipv6        = "2a02:8010:8006:3a39:c7:b6ff:fe06:98c3"
+      ipv6        = "2a02:8010:8006:3a39:65:a6ff:fee8:a87a"
     },
     { name        = "testing-02"
       environment = "testing"


### PR DESCRIPTION
Correct the IPv6 address for the `testing-01` host in the Testing environment following a change to the MAC address on the network interface.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
